### PR TITLE
chore: pin shared backup workflow to commit SHA (sc-62789)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Keeps the SHA-pinned actions in .github/workflows fresh.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 14

--- a/.github/workflows/backup-daily.yml
+++ b/.github/workflows/backup-daily.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   s3-backup-daily:
-    uses: narrative-io/common-github/.github/workflows/backup.yml@main
+    uses: narrative-io/common-github/.github/workflows/backup.yml@ad6b23573ee7a7573f6499818f61429cc5238e76 # 2026-07-16, post-hardening (sc-62809)
     # uses: ./.github/workflows/backup.yml
     secrets: inherit


### PR DESCRIPTION
Pins the shared backup workflow to a full commit SHA and adds Dependabot updates for github-actions.

[sc-62789](https://app.shortcut.com/narrativeio/story/62789)