### PR TITLE
ci: [SC-66825] run zizmor and fix GitHub Actions findings

### DIFF
--- a/.github/workflows/backup-daily.yml
+++ b/.github/workflows/backup-daily.yml
@@ -5,8 +5,12 @@ on:
     schedule:
       - cron: 0 6 * * *
 
+# backup.yml only uses GITHUB_TOKEN (passed to called workflows
+# automatically); AWS access comes from the runner's instance profile.
+permissions:
+  contents: read
+
 jobs:
   s3-backup-daily:
     uses: narrative-io/common-github/.github/workflows/backup.yml@ad6b23573ee7a7573f6499818f61429cc5238e76 # 2026-07-16, post-hardening (sc-62809)
     # uses: ./.github/workflows/backup.yml
-    secrets: inherit

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read         # Only needed for private repos. Needed to clone the repo.
+      actions: read          # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1


### PR DESCRIPTION
Runs [zizmor](https://docs.zizmor.sh/) in CI and fixes the findings it reports. Part of [sc-66825](https://app.shortcut.com/narrativeio/story/66825); modeled on `narrative-skills-marketplace` PR #108, the reference implementation for this ticket.
